### PR TITLE
Feat/break jobs

### DIFF
--- a/src/socm/bookkeeper/bookkeeper.py
+++ b/src/socm/bookkeeper/bookkeeper.py
@@ -166,12 +166,14 @@ class Bookkeeper(object):
         """
 
         self._checkpoints: List[float] = [0]
+        self._batch_start: float = float("inf")
 
         for plan_entry in plan_batch:
             if plan_entry.end_time not in self._checkpoints:
                 self._checkpoints.append(plan_entry.end_time)
             if plan_entry.start_time not in self._checkpoints:
                 self._checkpoints.append(plan_entry.start_time)
+            self._batch_start = min(self._batch_start, plan_entry.start_time)
 
         self._checkpoints.sort()
 
@@ -311,22 +313,27 @@ class Bookkeeper(object):
         # There is no need to check since I know there is no plan.
         self._logger.debug("Campaign state to PLANNING")
         self._prof.prof("planning_start", uid=self._uid)
-        if self._plan_result is None:
-            self._logger.debug("Calculating campaign plan")
+        try:
+            if self._plan_result is None:
+                self._logger.debug("Calculating campaign plan")
+                with self._exec_state_lock:
+                    self._campaign["state"] = States.PLANNING
+
+                workflow_requirements = self._get_campaign_requirements()
+
+                self._plan_result = self._planner.plan(
+                    campaign=self._campaign["campaign"].workflows,
+                    execution_schema=self._campaign["campaign"].execution_schema,
+                    resource_requirements=workflow_requirements,
+                    requested_resources=self._campaign["campaign"].requested_resources
+                )
+        except Exception as ex:
+            self._logger.error(f"Exception during planning: {ex}")
             with self._exec_state_lock:
-                self._campaign["state"] = States.PLANNING
-
-            workflow_requirements = self._get_campaign_requirements()
-
-            self._plan_result = self._planner.plan(
-                campaign=self._campaign["campaign"].workflows,
-                execution_schema=self._campaign["campaign"].execution_schema,
-                resource_requirements=workflow_requirements,
-                requested_resources=self._campaign["campaign"].requested_resources
-            )
-
-        self._planning_done.set()
-        self._prof.prof("planning_ended", uid=self._uid)
+                self._campaign["state"] = States.FAILED
+        finally:
+            self._planning_done.set()
+            self._prof.prof("planning_ended", uid=self._uid)
 
         self._logger.debug(f"Calculated campaign plan batches with {self._plan_result.qos} QOS and requesting {self._plan_result.ncores} cores")
         objective_met = self._verify_objective()
@@ -340,11 +347,13 @@ class Bookkeeper(object):
                 if self._terminate_event.is_set():
                     break
 
+                wf_id_lookup = {plan_entry.workflow.id: plan_entry for plan_entry in plan_batch.plan}
                 self._update_checkpoints(plan_batch.plan)
 
                 max_walltime = self._plan_result.qos.max_walltime if self._plan_result.qos is not None else float('inf')
+                batch_duration = self._checkpoints[-1] - self._batch_start
                 batch_walltime = int(
-                    ceil(min(self._checkpoints[-1] * 1.25, max_walltime))
+                    ceil(min(batch_duration * 1.25, max_walltime))
                 )
                 self._logger.debug(f"Resource max walltime for batch {batch_walltime}")
 
@@ -382,25 +391,25 @@ class Bookkeeper(object):
                             or predecessors_states == set([States.DONE])
                         ) and self._workflows_state[wf_id] == States.NEW:
                             node_slice = (
-                                plan_batch.plan[wf_id - 1][2] / self._resource.memory_per_node
+                                wf_id_lookup[wf_id].memory / self._resource.memory_per_node
                             )
                             threads_per_core = floor(
                                 self._resource.cores_per_node
                                 * node_slice
-                                / len(plan_batch.plan[wf_id - 1][1])
+                                / len(wf_id_lookup[wf_id].cores)
                             )
                             # print(node_slice, threads_per_core, self._plan[wf_id - 1])
-                            workflows.append(plan_batch.plan[wf_id - 1][0])
-                            cores.append((plan_batch.plan[wf_id - 1][1], threads_per_core))
-                            memory.append(plan_batch.plan[wf_id - 1][2])
+                            workflows.append(wf_id_lookup[wf_id].workflow)
+                            cores.append((wf_id_lookup[wf_id].cores, threads_per_core))
+                            memory.append(wf_id_lookup[wf_id].memory)
 
                             self._logger.debug(
                                 f"To submit workflows {[x for x in workflows]}"
                                 + f" to resources {cores}"
                             )
 
-                            for rc_id in plan_batch.plan[wf_id - 1][1]:
-                                self._est_end_times[rc_id] = plan_batch.plan[wf_id - 1][3]
+                            for rc_id in wf_id_lookup[wf_id].cores:
+                                self._est_end_times[rc_id] = wf_id_lookup[wf_id].end_time
                     if workflows:
                         self._logger.debug(
                             f"Submitting workflows {[x.id for x in workflows]}"

--- a/src/socm/bookkeeper/bookkeeper.py
+++ b/src/socm/bookkeeper/bookkeeper.py
@@ -4,7 +4,7 @@ from importlib.resources import files
 from math import ceil, floor
 from pathlib import Path
 from time import sleep
-from typing import Dict
+from typing import Dict, List
 
 import radical.utils as ru
 from slurmise.api import Slurmise
@@ -12,7 +12,7 @@ from slurmise.job_data import JobData
 from slurmise.job_parse.file_parsers import FileMD5
 from slurmise.slurm import parse_slurm_job_metadata
 
-from ..core import Campaign, Workflow
+from ..core import Campaign, PlanEntry, Workflow
 from ..enactor import DryrunEnactor, RPEnactor
 from ..planner import HeftPlanner
 from ..resources import registered_resources
@@ -60,8 +60,7 @@ class Bookkeeper(object):
 
         self._resource = registered_resources[target_resource]()
         self._checkpoints = None
-        self._plan = None
-        self._plan_graph = None
+        self._plan_result = None
         self._unavail_resources = []
         self._workflows_state = dict()
         self._workflows_execids = dict()
@@ -95,6 +94,9 @@ class Bookkeeper(object):
         # Creating a thread to execute the monitoring and work methods.
         # One flag for both threads may be enough  to monitor and check.
         self._terminate_event = mt.Event()  # Thread event to terminate.
+        self._batch_finished = mt.Event()  # Thread event to indicate batch completion.
+        self._planning_done = mt.Event()  # Thread event to indicate planning is complete.
+        self._current_batch_wf_ids = set()
         self._work_thread = None  # Private attribute that will hold the thread
         self._monitoring_thread = None  # Private attribute that will hold the thread
 
@@ -158,18 +160,18 @@ class Bookkeeper(object):
                 }
         return workflow_requirements
 
-    def _update_checkpoints(self):
+    def _update_checkpoints(self, plan_batch: List[PlanEntry]) -> None:
         """
         Create a list of timestamps when workflows may start executing or end.
         """
 
-        self._checkpoints = [0]
+        self._checkpoints: List[float] = [0]
 
-        for work in self._plan:
-            if work[-2] not in self._checkpoints:
-                self._checkpoints.append(work[-2])
-            if work[-1] not in self._checkpoints:
-                self._checkpoints.append(work[-1])
+        for plan_entry in plan_batch:
+            if plan_entry.end_time not in self._checkpoints:
+                self._checkpoints.append(plan_entry.end_time)
+            if plan_entry.start_time not in self._checkpoints:
+                self._checkpoints.append(plan_entry.start_time)
 
         self._checkpoints.sort()
 
@@ -180,7 +182,7 @@ class Bookkeeper(object):
         compares it with the maximum walltime.
         """
 
-        self._update_checkpoints()
+        self._update_checkpoints(self._plan_result.batches[-1].plan)
 
         if self._checkpoints[-1] > self._objective:
             return False
@@ -273,6 +275,11 @@ class Bookkeeper(object):
         with self._exec_state_lock:
             for workflow_id in workflow_ids:
                 self._workflows_state[workflow_id] = new_state
+            if self._current_batch_wf_ids and all(
+                self._workflows_state.get(wf_id) in CFINAL
+                for wf_id in self._current_batch_wf_ids
+            ):
+                self._batch_finished.set()
 
     def workflowid_update_cb(self, workflow_ids, step_ids, **kargs):
         """
@@ -304,124 +311,128 @@ class Bookkeeper(object):
         # There is no need to check since I know there is no plan.
         self._logger.debug("Campaign state to PLANNING")
         self._prof.prof("planning_start", uid=self._uid)
-        if self._plan is None:
+        if self._plan_result is None:
             self._logger.debug("Calculating campaign plan")
             with self._exec_state_lock:
                 self._campaign["state"] = States.PLANNING
 
             workflow_requirements = self._get_campaign_requirements()
 
-            self._plan, self._plan_graph, selected_qos, cores_request = self._planner.plan(
+            self._plan_result = self._planner.plan(
                 campaign=self._campaign["campaign"].workflows,
                 execution_schema=self._campaign["campaign"].execution_schema,
                 resource_requirements=workflow_requirements,
                 requested_resources=self._campaign["campaign"].requested_resources
             )
 
+        self._planning_done.set()
         self._prof.prof("planning_ended", uid=self._uid)
-        self._logger.debug(f"Calculated campaign plan with {selected_qos} QOS and requesting {cores_request} cores")
 
-        # Update checkpoints and objective.
-        self._update_checkpoints()
-        self._logger.debug(
-            f"Campaign makespan {self._checkpoints[-1]}, and objective {self._objective}"
-        )
-        if not self._verify_objective():
+        self._logger.debug(f"Calculated campaign plan batches with {self._plan_result.qos} QOS and requesting {self._plan_result.ncores} cores")
+        objective_met = self._verify_objective()
+
+        if not objective_met:
             self._logger.error("Objective cannot be satisfied. Ending execution")
             with self._exec_state_lock:
                 self._campaign["state"] = States.FAILED
-            sleep(1)
-            return
+        else:
+            for plan_batch in self._plan_result.batches:
+                if self._terminate_event.is_set():
+                    break
 
-        self._objective = int(
-            ceil(min(self._checkpoints[-1] * 1.25, self._objective))
-        )
-        self._logger.debug(f"Resource max walltime {self._objective}")
+                self._update_checkpoints(plan_batch.plan)
 
-        self._enactor.setup(
-            resource=self._resource,
-            walltime=self._objective,
-            cores=cores_request,
-            execution_schema=self._campaign["campaign"].execution_schema,
-        )
+                max_walltime = self._plan_result.qos.max_walltime if self._plan_result.qos is not None else float('inf')
+                batch_walltime = int(
+                    ceil(min(self._checkpoints[-1] * 1.25, max_walltime))
+                )
+                self._logger.debug(f"Resource max walltime for batch {batch_walltime}")
 
-        with self._exec_state_lock:
-            self._campaign["state"] = States.EXECUTING
-        self._logger.debug("Campaign state to EXECUTING")
+                self._enactor.setup(
+                    resource=self._resource,
+                    walltime=batch_walltime,
+                    cores=self._plan_result.ncores,
+                    execution_schema=self._campaign["campaign"].execution_schema,
+                )
 
-        self._prof.prof("work_start", uid=self._uid)
-        while not self._terminate_event.is_set():
-            if not self._verify_objective():
-                self._logger.error("Objective cannot be satisfied. Ending execution")
                 with self._exec_state_lock:
-                    self._campaign["state"] = States.FAILED
-                    # self.terminate()
-            else:
-                self._prof.prof("work_submit", uid=self._uid)
-                workflows = list()  # Workflows to enact
-                cores = list()  # The selected cores
-                memory = list()  # The memory per workflow
+                    if self._campaign["state"] != States.EXECUTING:
+                        self._campaign["state"] = States.EXECUTING
+                        self._logger.debug("Campaign state to EXECUTING")
 
-                for wf_id in self._plan_graph.nodes():
+                self._current_batch_wf_ids = set(plan_batch.graph.nodes())
+                self._batch_finished.clear()
 
-                    predecessors_states = set()
-                    for predecessor in self._plan_graph.predecessors(wf_id):
-                        predecessors_states.add(self._workflows_state[predecessor])
-                    # Do not enact to workflows that sould have been executed
-                    # already.
-                    if (
-                        predecessors_states == set()
-                        or predecessors_states == set([States.DONE])
-                    ) and self._workflows_state[wf_id] == States.NEW:
-                        node_slice = (
-                            self._plan[wf_id - 1][2] / self._resource.memory_per_node
-                        )
-                        threads_per_core = floor(
-                            self._resource.cores_per_node
-                            * node_slice
-                            / len(self._plan[wf_id - 1][1])
-                        )
-                        # print(node_slice, threads_per_core, self._plan[wf_id - 1])
-                        workflows.append(self._plan[wf_id - 1][0])
-                        cores.append((self._plan[wf_id - 1][1], threads_per_core))
-                        memory.append(self._plan[wf_id - 1][2])
+                self._prof.prof("work_start", uid=self._uid)
+                while not self._terminate_event.is_set() and not self._batch_finished.is_set():
+                    self._prof.prof("work_submit", uid=self._uid)
+                    workflows = list()  # Workflows to enact
+                    cores = list()  # The selected cores
+                    memory = list()  # The memory per workflow
 
+                    for wf_id in plan_batch.graph.nodes():
+
+                        predecessors_states = set()
+                        for predecessor in plan_batch.graph.predecessors(wf_id):
+                            predecessors_states.add(self._workflows_state[predecessor])
+                        # Do not enact to workflows that sould have been executed
+                        # already.
+                        if (
+                            predecessors_states == set()
+                            or predecessors_states == set([States.DONE])
+                        ) and self._workflows_state[wf_id] == States.NEW:
+                            node_slice = (
+                                plan_batch.plan[wf_id - 1][2] / self._resource.memory_per_node
+                            )
+                            threads_per_core = floor(
+                                self._resource.cores_per_node
+                                * node_slice
+                                / len(plan_batch.plan[wf_id - 1][1])
+                            )
+                            # print(node_slice, threads_per_core, self._plan[wf_id - 1])
+                            workflows.append(plan_batch.plan[wf_id - 1][0])
+                            cores.append((plan_batch.plan[wf_id - 1][1], threads_per_core))
+                            memory.append(plan_batch.plan[wf_id - 1][2])
+
+                            self._logger.debug(
+                                f"To submit workflows {[x for x in workflows]}"
+                                + f" to resources {cores}"
+                            )
+
+                            for rc_id in plan_batch.plan[wf_id - 1][1]:
+                                self._est_end_times[rc_id] = plan_batch.plan[wf_id - 1][3]
+                    if workflows:
                         self._logger.debug(
-                            f"To submit workflows {[x for x in workflows]}"
+                            f"Submitting workflows {[x.id for x in workflows]}"
                             + f" to resources {cores}"
                         )
 
-                        for rc_id in self._plan[wf_id - 1][1]:
-                            self._est_end_times[rc_id] = self._plan[wf_id - 1][3]
-                if workflows:
-                    self._logger.debug(
-                        f"Submitting workflows {[x.id for x in workflows]}"
-                        + f" to resources {cores}"
-                    )
+                    # There is no need to call the enactor when no new things
+                    # should happen.
+                    # self._logger.debug('Adding items: %s, %s', workflows, resources)
+                    if workflows and cores and memory:
+                        self._prof.prof("enactor_submit", uid=self._uid)
+                        self._enactor.enact(workflows=workflows)
+                        self._prof.prof("enactor_submitted", uid=self._uid)
 
-                # There is no need to call the enactor when no new things
-                # should happen.
-                # self._logger.debug('Adding items: %s, %s', workflows, resources)
-                if workflows and cores and memory:
-                    self._prof.prof("enactor_submit", uid=self._uid)
-                    self._enactor.enact(workflows=workflows)
-                    self._prof.prof("enactor_submitted", uid=self._uid)
-
-                    with self._monitor_lock:
-                        self._workflows_to_monitor += workflows
-                        self._unavail_resources += cores
-                        self._logger.info(
-                            f"Total number of workflows to monitor {len(workflows)}"
+                        with self._monitor_lock:
+                            self._workflows_to_monitor += workflows
+                            self._unavail_resources += cores
+                            self._logger.info(
+                                f"Total number of workflows to monitor {len(workflows)}"
+                            )
+                        self._logger.debug(
+                            "Things monitored: %s, %s, %s",
+                            self._workflows_to_monitor,
+                            self._unavail_resources,
+                            self._est_end_times,
                         )
-                    self._logger.debug(
-                        "Things monitored: %s, %s, %s",
-                        self._workflows_to_monitor,
-                        self._unavail_resources,
-                        self._est_end_times,
-                    )
 
-                self._prof.prof("work_submitted", uid=self._uid)
-            sleep(1)
+                    self._prof.prof("work_submitted", uid=self._uid)
+                    sleep(1)
+
+                if not self._terminate_event.is_set():
+                    self._enactor.teardown()
 
     def monitor(self):
         """
@@ -459,7 +470,7 @@ class Bookkeeper(object):
                 else:
                     sleep(1)  # Sleep for a while if nothing happened.
 
-        self._logger.debug("Monitor thread Stoped")
+        self._logger.debug("Monitor thread Stopped")
 
     def get_makespan(self):
         """
@@ -472,8 +483,8 @@ class Bookkeeper(object):
             completion time of the entire campaign (in minutes).
         """
 
-        self._update_checkpoints()
-
+        if self._checkpoints is None:
+            return 0
         return self._checkpoints[-1]
 
     def terminate(self):
@@ -534,8 +545,7 @@ class Bookkeeper(object):
             # self._logger.debug(
             #     "Time now: %s, checkpoints: %s", self._time, self._checkpoints
             # )
-            while self._checkpoints is None:
-                continue
+            self._planning_done.wait()
 
             self._prof.prof("bookkeper_wait", uid=self._uid)
             while self._campaign["state"] not in CFINAL:

--- a/src/socm/bookkeeper/bookkeeper.py
+++ b/src/socm/bookkeeper/bookkeeper.py
@@ -331,6 +331,7 @@ class Bookkeeper(object):
             self._logger.error(f"Exception during planning: {ex}")
             with self._exec_state_lock:
                 self._campaign["state"] = States.FAILED
+                return
         finally:
             self._planning_done.set()
             self._prof.prof("planning_ended", uid=self._uid)
@@ -350,7 +351,11 @@ class Bookkeeper(object):
                 wf_id_lookup = {plan_entry.workflow.id: plan_entry for plan_entry in plan_batch.plan}
                 self._update_checkpoints(plan_batch.plan)
 
-                max_walltime = self._plan_result.qos.max_walltime if self._plan_result.qos is not None else float('inf')
+                if self._plan_result.qos is not None and self._plan_result.qos.max_walltime is not None:
+                    max_walltime = self._plan_result.qos.max_walltime
+                else:
+                    max_walltime = float('inf')
+
                 batch_duration = self._checkpoints[-1] - self._batch_start
                 batch_walltime = int(
                     ceil(min(batch_duration * 1.25, max_walltime))

--- a/src/socm/core/__init__.py
+++ b/src/socm/core/__init__.py
@@ -1,1 +1,11 @@
-from .models import DAG, Campaign, QosPolicy, Resource, ResourceSpec, Workflow  # noqa: F401
+from .models import (  # noqa: F401
+    DAG,
+    Batch,
+    Campaign,
+    PlanEntry,
+    PlanResult,
+    QosPolicy,
+    Resource,
+    ResourceSpec,
+    Workflow,
+)

--- a/src/socm/core/models.py
+++ b/src/socm/core/models.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from numbers import Number
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Tuple, Union, get_args, get_origin
 
 import networkx as nx
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
@@ -350,3 +350,25 @@ class Campaign(BaseModel):
                             dag.add_dependency(name_to_id[dep_name], w.id)
             return dag
         return v
+
+
+class PlanEntry(NamedTuple):
+    """Represents a scheduled workflow in the execution plan."""
+    workflow: Workflow
+    cores: range
+    memory: float
+    start_time: float
+    end_time: float
+
+
+class Batch(NamedTuple):
+    """A group of workflows that execute within a single pilot submission."""
+    plan: List[PlanEntry]
+    graph: nx.DiGraph
+
+
+class PlanResult(NamedTuple):
+    """Complete output of the planning phase."""
+    qos: Optional[QosPolicy]  # None for batch execution schema
+    ncores: int
+    batches: List[Batch]  # Length 1 for single-submission campaigns

--- a/src/socm/enactor/base.py
+++ b/src/socm/enactor/base.py
@@ -149,3 +149,7 @@ class Enactor(object):
     def terminate(self):
         """Terminate the Enactor and clean up resources."""
         raise NotImplementedError("terminate is not implemented")
+
+    def teardown(self):
+        """Tear down the Enactor's backend, ensuring all resources are cleaned up."""
+        raise NotImplementedError("teardown is not implemented")

--- a/src/socm/enactor/dryrun_enactor.py
+++ b/src/socm/enactor/dryrun_enactor.py
@@ -241,3 +241,7 @@ class DryrunEnactor(Enactor):
         with self._cb_lock:
             cb_name = cb.__name__
             self._callbacks[cb_name] = cb
+
+    def teardown(self):
+        """Tear down the dry-run Enactor, ensuring all resources are cleaned up."""
+        self._logger.info("Tearing down the Enactor")

--- a/src/socm/enactor/rp_enactor.py
+++ b/src/socm/enactor/rp_enactor.py
@@ -46,6 +46,7 @@ class RPEnactor(Enactor):
         self._run = False
         self._resource = None
         self._prof.prof("enactor_started", uid=self._uid)
+        self._pilot = None
         self._rp_session = rp.Session(uid=sid)
         self._rp_pmgr = rp.PilotManager(session=self._rp_session)
         self._rp_tmgr = rp.TaskManager(session=self._rp_session)
@@ -79,10 +80,10 @@ class RPEnactor(Enactor):
 
         pdesc = rp.PilotDescription(pd_init)
         self._logger.debug(f"Asking for {pdesc} pilot")
-        pilot = self._rp_pmgr.submit_pilots(pdesc)
-        self._rp_tmgr.add_pilots(pilot)
+        self._pilot = self._rp_pmgr.submit_pilots(pdesc)
+        self._rp_tmgr.add_pilots(self._pilot)
 
-        pilot.wait(state=rp.PMGR_ACTIVE)
+        self._pilot.wait(state=rp.PMGR_ACTIVE)
         self._logger.info("Pilot is ready")
 
     def enact(self, workflows: List[Workflow]) -> None:
@@ -303,3 +304,14 @@ class RPEnactor(Enactor):
         with self._cb_lock:
             cb_name = cb.__name__
             self._callbacks[cb_name] = cb
+
+    def teardown(self):
+        """Tear down the Enactor's backend, ensuring all resources are cleaned up."""
+        self._logger.info("Tearing down the Pilot")
+        # No additional teardown needed for RADICAL-Pilot as terminate handles cleanup.
+        if self._pilot:
+            self._pilot.cancel()
+            self._pilot.wait(state=rp.PMGR_CANCELED)
+            self._pilot = None
+        else:
+            self._logger.warning("No pilot to cancel during teardown.")

--- a/src/socm/planner/__init__.py
+++ b/src/socm/planner/__init__.py
@@ -1,2 +1,3 @@
-from .base import PlanEntry, Planner  # noqa: F401
+from ..core import Batch, PlanEntry, PlanResult  # noqa: F401
+from .base import Planner  # noqa: F401
 from .heft_planner import HeftPlanner  # noqa: F401

--- a/src/socm/planner/base.py
+++ b/src/socm/planner/base.py
@@ -1,6 +1,7 @@
 import os
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
+import networkx as nx
 import radical.utils as ru
 
 from ..core import DAG, Campaign, PlanEntry, PlanResult, Resource
@@ -76,7 +77,7 @@ class Planner(object):
         resources: range | None = None,
         resource_requirements: Dict[int, Dict[str, float]] | None = None,
         start_time: int = 0,
-    ) -> PlanResult:
+    ) -> Tuple[List[PlanEntry], nx.DiGraph]:
         """
         Recalculate the execution plan, typically after workflow completion.
 
@@ -93,7 +94,7 @@ class Planner(object):
 
         Returns
         -------
-        PlanResult
-            The complete planning result containing QoS policy, core count, and execution batches.
+        Tuple[List[PlanEntry], nx.DiGraph]
+            A tuple containing the updated plan entries and the dependency graph.
         """
         raise NotImplementedError("Replan method is not implemented")

--- a/src/socm/planner/base.py
+++ b/src/socm/planner/base.py
@@ -1,19 +1,10 @@
 import os
-from typing import Dict, List, NamedTuple, Tuple
+from typing import Dict, List
 
-import networkx as nx
 import radical.utils as ru
 
-from ..core import DAG, Campaign, Resource, Workflow
+from ..core import DAG, Campaign, PlanEntry, PlanResult, Resource
 
-
-class PlanEntry(NamedTuple):
-    """Represents a scheduled workflow in the execution plan."""
-    workflow: Workflow
-    cores: range
-    memory: float
-    start_time: float
-    end_time: float
 
 class Planner(object):
     """
@@ -55,7 +46,7 @@ class Planner(object):
         resource_requirements: Dict[int, Dict[str, float]] | None = None,
         start_time: int = 0,
         **kargs,
-    ) -> Tuple[List[PlanEntry], nx.DiGraph]:
+    ) -> PlanResult:
         """
         Calculate an execution plan for the given campaign and resources.
 
@@ -74,12 +65,9 @@ class Planner(object):
 
         Returns
         -------
-        tuple[list[PlanEntry], nx.DiGraph]
-            A tuple of (plan_entries, dependency_graph) where plan_entries
-            is a list of PlanEntry named tuples and dependency_graph is a
-            NetworkX DiGraph.
+        PlanResult
+            The complete planning result containing QoS policy, core count, and execution batches.
         """
-
         raise NotImplementedError("Plan method is not implemented")
 
     def replan(
@@ -88,11 +76,9 @@ class Planner(object):
         resources: range | None = None,
         resource_requirements: Dict[int, Dict[str, float]] | None = None,
         start_time: int = 0,
-    ) -> Tuple[List[PlanEntry], nx.DiGraph]:
+    ) -> PlanResult:
         """
         Recalculate the execution plan, typically after workflow completion.
-
-        Delegates to ``plan()`` if all required arguments are provided.
 
         Parameters
         ----------
@@ -107,18 +93,7 @@ class Planner(object):
 
         Returns
         -------
-        tuple
-            A tuple of (plan_entries, dependency_graph).
+        PlanResult
+            The complete planning result containing QoS policy, core count, and execution batches.
         """
-        if campaign and resources and resource_requirements:
-            self._logger.debug("Replanning")
-            self._plan = self.plan(
-                campaign=campaign,
-                resources=resources,
-                resource_requirements=resource_requirements,
-                start_time=start_time,
-            )
-        else:
-            self._logger.debug("Nothing to plan for")
-
-        return self._plan
+        raise NotImplementedError("replan method is not implemented")

--- a/src/socm/planner/base.py
+++ b/src/socm/planner/base.py
@@ -96,4 +96,4 @@ class Planner(object):
         PlanResult
             The complete planning result containing QoS policy, core count, and execution batches.
         """
-        raise NotImplementedError("replan method is not implemented")
+        raise NotImplementedError("Replan method is not implemented")

--- a/src/socm/planner/heft_planner.py
+++ b/src/socm/planner/heft_planner.py
@@ -249,7 +249,7 @@ class HeftPlanner(Planner):
             splittable,
             key=lambda q: q.max_walltime if q.max_walltime is not None else float('inf')
         )
-        max_walltime = best_qos.max_walltime
+        max_walltime = best_qos.max_walltime or float('inf')
 
         # Validate that no individual workflow exceeds the batch window
         for entry in plan:

--- a/src/socm/planner/heft_planner.py
+++ b/src/socm/planner/heft_planner.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Tuple
 import networkx as nx
 import numpy as np
 
-from ..core import DAG, Campaign, QosPolicy, Resource
-from .base import PlanEntry, Planner
+from ..core import DAG, Batch, Campaign, PlanEntry, PlanResult, QosPolicy, Resource
+from .base import Planner
 
 
 class HeftPlanner(Planner):
@@ -121,16 +121,89 @@ class HeftPlanner(Planner):
             return best_ncores, best_plan, best_graph
         return None
 
+    def _build_batch_subgraph(self, graph: nx.DiGraph, workflow_ids: List[int | None]) -> nx.DiGraph:
+        """Extract the subgraph for a batch, dropping cross-batch edges.
+
+        Args:
+            graph: Full plan dependency graph
+            workflow_ids: Workflow IDs belonging to this batch
+
+        Returns:
+            DiGraph containing only intra-batch nodes and edges
+        """
+        id_set = set(workflow_ids)
+        subgraph = nx.DiGraph()
+        for wf_id in workflow_ids:
+            subgraph.add_node(wf_id)
+        for wf_id in workflow_ids:
+            for successor in graph.successors(wf_id):
+                if successor in id_set:
+                    subgraph.add_edge(wf_id, successor)
+        return subgraph
+
+    def _split_plan_into_batches(
+        self, plan: List[PlanEntry], graph: nx.DiGraph, max_walltime: float
+    ) -> List[Batch]:
+        """Split a plan into batches where each batch fits within max_walltime.
+
+        Entries are assigned to batches greedily by end_time. A new batch starts
+        when the next entry's end_time would exceed the current batch window.
+        Cross-batch dependency edges are dropped because sequential batch execution
+        guarantees ordering.
+
+        Args:
+            plan: Full list of plan entries (will be sorted by end_time internally)
+            graph: Full plan dependency graph
+            max_walltime: Maximum duration (in plan time units) per batch
+
+        Returns:
+            List of Batch objects
+        """
+        sorted_plan = sorted(plan, key=lambda e: e.end_time)
+        batches: List[Batch] = []
+        current_batch: List[PlanEntry] = []
+        batch_start = 0.0
+
+        for entry in sorted_plan:
+            tentative_start = min(batch_start, entry.start_time) if current_batch else entry.start_time
+
+            if entry.end_time > tentative_start + max_walltime:
+                if current_batch:
+                    batch_wf_ids = [e.workflow.id for e in current_batch]
+                    batches.append(Batch(
+                        plan=current_batch,
+                        graph=self._build_batch_subgraph(graph, batch_wf_ids)
+                    ))
+                batch_start = entry.start_time
+                current_batch = []
+            else:
+                batch_start = tentative_start
+
+            current_batch.append(entry)
+
+        if current_batch:
+            batch_wf_ids = [e.workflow.id for e in current_batch]
+            batches.append(Batch(
+                plan=current_batch,
+                graph=self._build_batch_subgraph(graph, batch_wf_ids)
+            ))
+
+        return batches
+
     def _plan_with_qos_optimization(
         self,
         campaign: DAG,
         resource_requirements: Dict[int, Dict[str, float]],
         requested_resources: int,
-    ) -> Tuple[List[PlanEntry], nx.DiGraph, str, int]:
+    ) -> PlanResult:
         """Find optimal QoS and resource allocation for the campaign.
 
+        Attempts a single-pilot fit first. If no single QoS policy can accommodate
+        both the required cores and the campaign deadline, the plan is split into
+        sequential batches using the highest-walltime QoS that covers the core count.
+
         Returns:
-            Tuple of (plan, graph, qos_name, ncores).
+            PlanResult with qos, ncores, and one or more batches.
         """
         max_workflow_resources = self._get_max_ncores(resource_requirements)
         upper_bound = requested_resources
@@ -140,16 +213,60 @@ class HeftPlanner(Planner):
             campaign, resource_requirements, lower_bound, upper_bound
         )
 
-        if result is not None:
-            ncores, plan, plan_graph = result
-            qos_candidate = self._find_suitable_qos_policies(requested_cores=ncores)
-            self._logger.info(f"Plan to execute {plan} with {ncores} cores")
-            return plan, plan_graph, qos_candidate.name, ncores
-        else:
+        if result is None:
             raise ValueError(
                 f"Cannot meet {self._objective} min deadline with {requested_resources} cores. "
                 f"Please increase deadline or increase requested cores."
             )
+
+        ncores, plan, plan_graph = result
+
+        # Try single-QoS fit (deadline fits within one pilot)
+        qos_candidate = self._resources.fits_in_qos(self._objective, cores=ncores)
+        if qos_candidate is not None:
+            self._logger.info(
+                f"Plan fits in single QoS {qos_candidate.name} with {ncores} cores"
+            )
+            return PlanResult(
+                qos=qos_candidate,
+                ncores=ncores,
+                batches=[Batch(plan=plan, graph=plan_graph)]
+            )
+
+        # No single QoS fits — find best QoS by walltime among those with enough cores
+        splittable = [
+            q for q in self._resources.qos
+            if q.max_cores is None or q.max_cores >= ncores
+        ]
+        if not splittable:
+            available_qos = ', '.join(f"{q.name}(max_cores={q.max_cores})" for q in self._resources.qos)
+            raise ValueError(
+                f"No QoS policy has max_cores >= {ncores}. "
+                f"Campaign is infeasible. Available: {available_qos}"
+            )
+
+        best_qos = max(
+            splittable,
+            key=lambda q: q.max_walltime if q.max_walltime is not None else float('inf')
+        )
+        max_walltime = best_qos.max_walltime
+
+        # Validate that no individual workflow exceeds the batch window
+        for entry in plan:
+            wf_duration = entry.end_time - entry.start_time
+            if wf_duration > max_walltime:
+                raise ValueError(
+                    f"Workflow '{entry.workflow.name}' requires {wf_duration:.1f} min, "
+                    f"which exceeds QoS '{best_qos.name}' max walltime of {max_walltime} min. "
+                    "Campaign is infeasible."
+                )
+
+        batches = self._split_plan_into_batches(plan, plan_graph, max_walltime)
+        self._logger.info(
+            f"Plan split into {len(batches)} batches using QoS {best_qos.name} "
+            f"(max_walltime={max_walltime} min) with {ncores} cores"
+        )
+        return PlanResult(qos=best_qos, ncores=ncores, batches=batches)
 
     def _get_plan_graph(
         self, plan: List[PlanEntry], resources: range
@@ -197,12 +314,13 @@ class HeftPlanner(Planner):
         resource_requirements: Dict[int, Dict[str, float]] | None = None,
         execution_schema: str | None = None,
         requested_resources: int | None = None
-    ) -> Tuple[List[PlanEntry], nx.DiGraph, QosPolicy | None, int]:
+    ) -> PlanResult:
         """Plan campaign execution with resource allocation.
 
         In batch mode, uses the requested resources directly.
         In remote mode, performs QoS selection and binary search to find the minimum
-        resources that satisfy the campaign deadline.
+        resources that satisfy the campaign deadline, splitting into multiple batches
+        if no single QoS policy covers both cores and deadline.
 
         Parameters
         ----------
@@ -217,11 +335,9 @@ class HeftPlanner(Planner):
 
         Returns
         -------
-        Tuple[plan, graph, qos, ncores]
-            - plan: List of PlanEntry tuples
-            - graph: DAG representation of the campaign
-            - qos: QoS policy name (None for batch mode)
-            - ncores: Number of cores allocated
+        PlanResult
+            Contains the selected QoS policy (None for batch mode), core count,
+            and one or more Batch objects representing pilot submissions.
         """
         if execution_schema == "batch":
             return self._plan_batch_mode(campaign, resource_requirements, requested_resources)
@@ -233,15 +349,15 @@ class HeftPlanner(Planner):
         campaign: DAG,
         resource_requirements: Dict[int, Dict[str, float]],
         requested_resources: int
-    ) -> Tuple[List[PlanEntry], nx.DiGraph, None, int]:
-        """Plan execution for batch mode with fixed resources."""
+    ) -> PlanResult:
+        """Plan execution for batch mode with fixed resources (single batch, no QoS)."""
         plan, plan_graph = self._calculate_plan(
             campaign=campaign,
             resources=range(requested_resources),
             resource_requirements=resource_requirements
         )
         self._logger.info(f"Plan to execute {plan} with {requested_resources} cores")
-        return plan, plan_graph, None, requested_resources
+        return PlanResult(qos=None, ncores=requested_resources, batches=[Batch(plan=plan, graph=plan_graph)])
 
     def _initialize_resource_estimates(self, resource_requirements: Dict[int, Dict[str, float]], widxs: List[int]
     ) -> Dict[str, List[float]]:
@@ -254,9 +370,9 @@ class HeftPlanner(Planner):
             estimated_walltime.append(resource_requirements[widx]["req_walltime"])
             estimated_cpus.append(resource_requirements[widx]["req_cpus"])
             estimated_memory.append(resource_requirements[widx]["req_memory"])
-        return {"estimated_walltime" : estimated_walltime,
-                "estimated_cpus" : estimated_cpus,
-                "estimated_memory" : estimated_memory}
+        return {"estimated_walltime": estimated_walltime,
+                "estimated_cpus": estimated_cpus,
+                "estimated_memory": estimated_memory}
 
     def _get_sorted_workflow_indices(self, estimated_walltime: List[float]) -> List[int]:
         """Get workflow indices sorted by execution time (longest first).
@@ -363,8 +479,6 @@ class HeftPlanner(Planner):
         Returns:
             Tuple of (execution_plan, dependency_graph)
         """
-        # Use provided parameters or fall back to instance attributes
-
         workflow_levels = campaign.levels if campaign else self._campaign.workflows.levels
 
         cores = (
@@ -424,7 +538,6 @@ class HeftPlanner(Planner):
         self._logger.debug("Potential plan %s", self._plan)
 
         return self._plan, plan_graph
-
 
     def replan(
         self,

--- a/tests/test_bookkeeper.py
+++ b/tests/test_bookkeeper.py
@@ -1,8 +1,69 @@
+import threading as mt
 from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import networkx as nx
 
 from socm.bookkeeper import Bookkeeper
-from socm.core.models import ResourceSpec
+from socm.core.models import Batch, PlanEntry, PlanResult, ResourceSpec
+from socm.utils.states import States
 from socm.workflows import MLMapmakingWorkflow, SpectraWorkflow
+
+# ─── helpers for multi-batch tests ───────────────────────────────────────────
+
+def _wf(wf_id):
+    wf = MagicMock()
+    wf.id = wf_id
+    wf.name = f"wf_{wf_id}"
+    wf.depends = []
+    return wf
+
+
+def _entry(wf, start, end):
+    return PlanEntry(workflow=wf, cores=range(2), memory=1000.0,
+                     start_time=float(start), end_time=float(end))
+
+
+def _batch(plan, node_ids):
+    g = nx.DiGraph()
+    for nid in node_ids:
+        g.add_node(nid)
+    return Batch(plan=plan, graph=g)
+
+
+def _make_bk(batches, objective=100.0):
+    """Bypass __init__ and wire up the minimal state needed for unit tests."""
+    bk = Bookkeeper.__new__(Bookkeeper)
+    bk._uid = "bookkeeper.test"
+    bk._logger = MagicMock()
+    bk._prof = MagicMock()
+    # Use real RLocks so that concurrent callback calls work correctly.
+    bk._exec_state_lock = mt.RLock()
+    bk._monitor_lock = mt.RLock()
+    bk._terminate_event = mt.Event()
+    bk._batch_finished = mt.Event()
+    bk._planning_done = mt.Event()
+    bk._current_batch_wf_ids = set()
+    bk._checkpoints = None
+    bk._objective = objective
+    bk._workflows_state = {}
+    bk._workflows_to_monitor = []
+    bk._unavail_resources = []
+    bk._est_end_times = {}
+    campaign = MagicMock()
+    campaign.execution_schema = "batch"
+    bk._campaign = {"campaign": campaign, "state": States.NEW}
+    bk._resource = MagicMock()
+    bk._resource.memory_per_node = 1000.0
+    bk._resource.cores_per_node = 4
+    bk._dryrun = True
+    bk._plan_result = PlanResult(qos=None, ncores=2, batches=batches)
+    bk._enactor = MagicMock()
+    # Populate workflow states for every workflow that appears in any batch graph.
+    for batch in batches:
+        for node_id in batch.graph.nodes():
+            bk._workflows_state[node_id] = States.NEW
+    return bk
 
 
 @mock.patch.object(Bookkeeper, "__init__", return_value=None)
@@ -156,3 +217,133 @@ def test_record_excludes_depends_from_categorical(mocked_logger, mocked_init, mo
     workflow.get_categorical_fields.assert_called_once_with(
         avoid_attributes=["executable", "name", "context", "output_dir", "query", "depends"]
     )
+
+
+# ─── _update_checkpoints ─────────────────────────────────────────────────────
+
+def test_update_checkpoints_basic():
+    bk = _make_bk(batches=[])
+    wf = _wf(1)
+    bk._update_checkpoints([_entry(wf, 10.0, 40.0), _entry(wf, 50.0, 80.0)])
+    assert bk._checkpoints == [0, 10.0, 40.0, 50.0, 80.0]
+
+
+def test_update_checkpoints_deduplicates_shared_boundary():
+    bk = _make_bk(batches=[])
+    wf = _wf(1)
+    bk._update_checkpoints([_entry(wf, 0.0, 30.0), _entry(wf, 30.0, 60.0)])
+    assert bk._checkpoints == [0, 30.0, 60.0]
+
+
+# ─── _verify_objective ───────────────────────────────────────────────────────
+
+def test_verify_objective_passes_when_makespan_within_deadline():
+    wf = _wf(1)
+    batch = _batch([_entry(wf, 0, 50)], [1])
+    bk = _make_bk([batch], objective=100.0)
+    assert bk._verify_objective() is True
+
+
+def test_verify_objective_fails_when_makespan_exceeds_deadline():
+    wf = _wf(1)
+    batch = _batch([_entry(wf, 0, 150)], [1])
+    bk = _make_bk([batch], objective=100.0)
+    assert bk._verify_objective() is False
+
+
+# ─── state_update_cb ─────────────────────────────────────────────────────────
+
+def test_state_update_cb_sets_batch_finished_when_all_done():
+    bk = _make_bk(batches=[])
+    bk._current_batch_wf_ids = {1, 2}
+    bk._workflows_state = {1: States.NEW, 2: States.NEW}
+
+    bk.state_update_cb(workflow_ids=[1, 2], new_state=States.DONE)
+
+    assert bk._batch_finished.is_set()
+
+
+def test_state_update_cb_no_batch_finished_when_partial():
+    bk = _make_bk(batches=[])
+    bk._current_batch_wf_ids = {1, 2}
+    bk._workflows_state = {1: States.NEW, 2: States.NEW}
+
+    bk.state_update_cb(workflow_ids=[1], new_state=States.DONE)
+
+    assert not bk._batch_finished.is_set()
+
+
+def test_state_update_cb_no_batch_finished_when_no_current_batch():
+    bk = _make_bk(batches=[])
+    bk._current_batch_wf_ids = set()
+    bk._workflows_state = {1: States.NEW}
+
+    bk.state_update_cb(workflow_ids=[1], new_state=States.DONE)
+
+    assert not bk._batch_finished.is_set()
+
+
+# ─── work() ──────────────────────────────────────────────────────────────────
+
+@patch("socm.bookkeeper.bookkeeper.sleep")
+def test_work_single_batch_setup_and_teardown(mock_sleep):
+    wf1 = _wf(1)
+    plan = [_entry(wf1, 0, 50)]
+    bk = _make_bk([_batch(plan, [1])], objective=100.0)
+
+    def mock_enact(workflows):
+        bk.state_update_cb(workflow_ids=[w.id for w in workflows], new_state=States.DONE)
+    bk._enactor.enact.side_effect = mock_enact
+
+    bk.work()
+
+    assert bk._planning_done.is_set()
+    bk._enactor.setup.assert_called_once()
+    bk._enactor.teardown.assert_called_once()
+
+
+@patch("socm.bookkeeper.bookkeeper.sleep")
+def test_work_multi_batch_setup_and_teardown_per_batch(mock_sleep):
+    # Use the full sorted plan in both batches so plan[wf_id-1] indexing works.
+    wf1, wf2 = _wf(1), _wf(2)
+    full_plan = [_entry(wf1, 0, 30), _entry(wf2, 30, 60)]
+    bk = _make_bk([_batch(full_plan, [1]), _batch(full_plan, [2])], objective=100.0)
+
+    def mock_enact(workflows):
+        bk.state_update_cb(workflow_ids=[w.id for w in workflows], new_state=States.DONE)
+    bk._enactor.enact.side_effect = mock_enact
+
+    bk.work()
+
+    assert bk._enactor.setup.call_count == 2
+    assert bk._enactor.teardown.call_count == 2
+    assert bk._planning_done.is_set()
+
+
+@patch("socm.bookkeeper.bookkeeper.sleep")
+def test_work_failed_objective_sets_planning_done_and_no_setup(mock_sleep):
+    wf1 = _wf(1)
+    plan = [_entry(wf1, 0, 200)]  # makespan exceeds objective of 100
+    bk = _make_bk([_batch(plan, [1])], objective=100.0)
+
+    bk.work()
+
+    assert bk._planning_done.is_set()
+    assert bk._campaign["state"] == States.FAILED
+    bk._enactor.setup.assert_not_called()
+    bk._enactor.teardown.assert_not_called()
+
+
+@patch("socm.bookkeeper.bookkeeper.sleep")
+def test_work_terminate_event_skips_teardown(mock_sleep):
+    wf1 = _wf(1)
+    plan = [_entry(wf1, 0, 50)]
+    bk = _make_bk([_batch(plan, [1])], objective=100.0)
+
+    def mock_enact(workflows):
+        bk._terminate_event.set()
+    bk._enactor.enact.side_effect = mock_enact
+
+    bk.work()
+
+    bk._enactor.teardown.assert_not_called()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,11 +2,12 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import humanfriendly
+import networkx as nx
 import numpy as np
 import pytest
 
 from socm.core import DAG, Campaign, QosPolicy, Resource, ResourceSpec, Workflow
-from socm.planner import HeftPlanner, PlanEntry
+from socm.planner import HeftPlanner, PlanEntry, PlanResult
 from socm.resources import TigerResource
 
 
@@ -432,3 +433,324 @@ def test_find_suitable_qos_policies_basic(mocked_init):
     assert suitable == QosPolicy(name="long", max_walltime=240, max_jobs=10, max_cores=400)
     with pytest.raises(ValueError):
         planner._find_suitable_qos_policies(requested_cores=410)
+
+
+# ------------------------------------------------------------------------------
+# _build_batch_subgraph
+# ------------------------------------------------------------------------------
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_build_batch_subgraph_keeps_intra_edges(mocked_init):
+    """Edges between nodes in the same batch are preserved."""
+    planner = HeftPlanner(None, None, None)
+
+    graph = nx.DiGraph()
+    graph.add_edges_from([(1, 2), (2, 3), (3, 4)])
+
+    subgraph = planner._build_batch_subgraph(graph, [1, 2, 3])
+
+    assert set(subgraph.nodes()) == {1, 2, 3}
+    assert set(subgraph.edges()) == {(1, 2), (2, 3)}
+
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_build_batch_subgraph_drops_cross_edges(mocked_init):
+    """Edges from nodes outside the batch are not included in the subgraph."""
+    planner = HeftPlanner(None, None, None)
+
+    graph = nx.DiGraph()
+    graph.add_edges_from([(1, 2), (2, 3), (3, 4)])
+
+    subgraph = planner._build_batch_subgraph(graph, [4])
+
+    assert set(subgraph.nodes()) == {4}
+    assert list(subgraph.edges()) == []
+
+
+# ------------------------------------------------------------------------------
+# _split_plan_into_batches
+# ------------------------------------------------------------------------------
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_split_plan_single_batch(mocked_init):
+    """All entries fit within max_walltime → one batch containing all entries."""
+    planner = HeftPlanner(None, None, None)
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    w2 = Workflow(name="W2", executable="exe", context="ctx", subcommand="sub", id=2)
+    w3 = Workflow(name="W3", executable="exe", context="ctx", subcommand="sub", id=3)
+
+    plan = [
+        PlanEntry(workflow=w1, cores=range(0, 4), memory=100, start_time=0, end_time=50),
+        PlanEntry(workflow=w2, cores=range(0, 4), memory=100, start_time=0, end_time=60),
+        PlanEntry(workflow=w3, cores=range(0, 4), memory=100, start_time=50, end_time=80),
+    ]
+
+    graph = nx.DiGraph()
+    for i in [1, 2, 3]:
+        graph.add_node(i)
+
+    batches = planner._split_plan_into_batches(plan, graph, max_walltime=100)
+
+    assert len(batches) == 1
+    assert len(batches[0].plan) == 3
+
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_split_plan_multi_batch(mocked_init):
+    """Entries spanning two windows produce two batches; cross-batch edge is dropped."""
+    planner = HeftPlanner(None, None, None)
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    w2 = Workflow(name="W2", executable="exe", context="ctx", subcommand="sub", id=2)
+
+    plan = [
+        PlanEntry(workflow=w1, cores=range(0, 4), memory=100, start_time=0, end_time=50),
+        PlanEntry(workflow=w2, cores=range(0, 4), memory=100, start_time=50, end_time=110),
+    ]
+
+    graph = nx.DiGraph()
+    graph.add_edge(1, 2)
+
+    batches = planner._split_plan_into_batches(plan, graph, max_walltime=100)
+
+    assert len(batches) == 2
+    assert batches[0].plan[0].workflow.id == 1
+    assert batches[1].plan[0].workflow.id == 2
+    assert not batches[0].graph.has_edge(1, 2)
+    assert not batches[1].graph.has_edge(1, 2)
+
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_split_plan_early_start_triggers_split(mocked_init):
+    """An entry with start_time earlier than the current batch_start correctly
+    triggers a new batch when the expanded window would exceed max_walltime.
+
+    W1: [10, 50), W2: [0, 60) — sorted by end_time gives W1 then W2.
+    After W1: batch_start=10.
+    W2 start_time=0 → tentative_start=min(10,0)=0; 60 > 0+55=55 → split.
+    Without the fix (keeping batch_start=10): 60 > 10+55=65 is False → no split,
+    but the actual window [0, 60) has duration 60 > 55.
+    """
+    planner = HeftPlanner(None, None, None)
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    w2 = Workflow(name="W2", executable="exe", context="ctx", subcommand="sub", id=2)
+
+    plan = [
+        PlanEntry(workflow=w1, cores=range(0, 4), memory=100, start_time=10, end_time=50),
+        PlanEntry(workflow=w2, cores=range(0, 4), memory=100, start_time=0, end_time=60),
+    ]
+
+    graph = nx.DiGraph()
+    graph.add_node(1)
+    graph.add_node(2)
+
+    batches = planner._split_plan_into_batches(plan, graph, max_walltime=55)
+
+    assert len(batches) == 2
+    assert batches[0].plan[0].workflow.id == 1
+    assert batches[1].plan[0].workflow.id == 2
+
+
+# ------------------------------------------------------------------------------
+# _plan_with_qos_optimization
+# ------------------------------------------------------------------------------
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_plan_with_qos_optimization_single_fit(mocked_init):
+    """When the deadline fits in one QoS window, returns a one-batch PlanResult."""
+    planner = HeftPlanner(None, None, None)
+    planner._logger = MagicMock()
+    planner._objective = 200
+
+    planner._resources = TigerResource(
+        name="tiger3", nodes=2, cores_per_node=112, memory_per_node=64 * 1024
+    )
+    planner._resources.qos = [
+        QosPolicy(name="short", max_walltime=1440, max_jobs=50, max_cores=1000),
+    ]
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    mock_plan = [
+        PlanEntry(workflow=w1, cores=range(0, 112), memory=1000, start_time=0, end_time=200)
+    ]
+    mock_graph = nx.DiGraph()
+    mock_graph.add_node(1)
+
+    resource_requirements = {1: {"req_cpus": 112, "req_memory": 1000, "req_walltime": 200}}
+
+    with mock.patch.object(planner, "_binary_search_resources", return_value=(112, mock_plan, mock_graph)):
+        result = planner._plan_with_qos_optimization(
+            campaign=MagicMock(),
+            resource_requirements=resource_requirements,
+            requested_resources=224,
+        )
+
+    assert isinstance(result, PlanResult)
+    assert len(result.batches) == 1
+    assert result.qos is not None
+    assert result.qos.name == "short"
+    assert result.ncores == 112
+
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_plan_with_qos_optimization_multi_batch(mocked_init):
+    """When no single QoS covers the deadline, the plan is split into multiple batches."""
+    planner = HeftPlanner(None, None, None)
+    planner._logger = MagicMock()
+    planner._objective = 10000  # Exceeds any single QoS window
+
+    planner._resources = TigerResource(
+        name="tiger3", nodes=2, cores_per_node=112, memory_per_node=64 * 1024
+    )
+    planner._resources.qos = [
+        QosPolicy(name="short", max_walltime=200, max_jobs=50, max_cores=500),
+    ]
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    w2 = Workflow(name="W2", executable="exe", context="ctx", subcommand="sub", id=2)
+    mock_plan = [
+        PlanEntry(workflow=w1, cores=range(0, 100), memory=1000, start_time=0, end_time=150),
+        PlanEntry(workflow=w2, cores=range(0, 100), memory=1000, start_time=150, end_time=350),
+    ]
+    mock_graph = nx.DiGraph()
+    mock_graph.add_edge(1, 2)
+
+    resource_requirements = {
+        1: {"req_cpus": 100, "req_memory": 1000, "req_walltime": 150},
+        2: {"req_cpus": 100, "req_memory": 1000, "req_walltime": 200},
+    }
+
+    with mock.patch.object(planner, "_binary_search_resources", return_value=(100, mock_plan, mock_graph)):
+        result = planner._plan_with_qos_optimization(
+            campaign=MagicMock(),
+            resource_requirements=resource_requirements,
+            requested_resources=200,
+        )
+
+    assert isinstance(result, PlanResult)
+    assert len(result.batches) == 2
+    assert result.qos.name == "short"
+    assert result.ncores == 100
+
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_plan_with_qos_optimization_infeasible_cannot_meet_deadline(mocked_init):
+    """Raises ValueError when binary search cannot find a plan meeting the deadline."""
+    planner = HeftPlanner(None, None, None)
+    planner._logger = MagicMock()
+    planner._objective = 10
+
+    planner._resources = TigerResource(
+        name="tiger3", nodes=2, cores_per_node=112, memory_per_node=64 * 1024
+    )
+
+    resource_requirements = {1: {"req_cpus": 112, "req_memory": 1000, "req_walltime": 100}}
+
+    with mock.patch.object(planner, "_binary_search_resources", return_value=None):
+        with pytest.raises(ValueError):
+            planner._plan_with_qos_optimization(
+                campaign=MagicMock(),
+                resource_requirements=resource_requirements,
+                requested_resources=224,
+            )
+
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_plan_with_qos_optimization_infeasible_no_qos_for_cores(mocked_init):
+    """Raises ValueError when no QoS policy can accommodate the required core count."""
+    planner = HeftPlanner(None, None, None)
+    planner._logger = MagicMock()
+    planner._objective = 10000  # Deadline too long for any single QoS window
+
+    planner._resources = TigerResource(
+        name="tiger3", nodes=2, cores_per_node=112, memory_per_node=64 * 1024
+    )
+    # All QoS policies have max_cores < 100 (ncores returned by binary search)
+    planner._resources.qos = [
+        QosPolicy(name="tiny", max_walltime=50, max_jobs=10, max_cores=50),
+    ]
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    mock_plan = [
+        PlanEntry(workflow=w1, cores=range(0, 100), memory=1000, start_time=0, end_time=30)
+    ]
+    mock_graph = nx.DiGraph()
+    mock_graph.add_node(1)
+
+    resource_requirements = {1: {"req_cpus": 100, "req_memory": 1000, "req_walltime": 30}}
+
+    with mock.patch.object(planner, "_binary_search_resources", return_value=(100, mock_plan, mock_graph)):
+        with pytest.raises(ValueError):
+            planner._plan_with_qos_optimization(
+                campaign=MagicMock(),
+                resource_requirements=resource_requirements,
+                requested_resources=200,
+            )
+
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_plan_with_qos_optimization_infeasible_workflow_too_long(mocked_init):
+    """Raises ValueError when a single workflow's duration exceeds the best QoS walltime."""
+    planner = HeftPlanner(None, None, None)
+    planner._logger = MagicMock()
+    planner._objective = 10000  # Exceeds any single QoS window
+
+    planner._resources = TigerResource(
+        name="tiger3", nodes=2, cores_per_node=112, memory_per_node=64 * 1024
+    )
+    # QoS has enough cores but walltime cap of 100 min
+    planner._resources.qos = [
+        QosPolicy(name="short", max_walltime=100, max_jobs=50, max_cores=500),
+    ]
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    # W1 duration = 150 > max_walltime=100 → infeasible
+    mock_plan = [
+        PlanEntry(workflow=w1, cores=range(0, 50), memory=1000, start_time=0, end_time=150)
+    ]
+    mock_graph = nx.DiGraph()
+    mock_graph.add_node(1)
+
+    resource_requirements = {1: {"req_cpus": 50, "req_memory": 1000, "req_walltime": 150}}
+
+    with mock.patch.object(planner, "_binary_search_resources", return_value=(50, mock_plan, mock_graph)):
+        with pytest.raises(ValueError):
+            planner._plan_with_qos_optimization(
+                campaign=MagicMock(),
+                resource_requirements=resource_requirements,
+                requested_resources=200,
+            )
+
+
+# ------------------------------------------------------------------------------
+# _plan_batch_mode
+# ------------------------------------------------------------------------------
+
+@mock.patch.object(HeftPlanner, "__init__", return_value=None)
+def test_plan_batch_mode_returns_plan_result(mocked_init):
+    """_plan_batch_mode wraps the calculated plan in a PlanResult with qos=None."""
+    planner = HeftPlanner(None, None, None)
+    planner._logger = MagicMock()
+
+    w1 = Workflow(name="W1", executable="exe", context="ctx", subcommand="sub", id=1)
+    mock_plan = [PlanEntry(workflow=w1, cores=range(0, 4), memory=100, start_time=0, end_time=50)]
+    mock_graph = nx.DiGraph()
+    mock_graph.add_node(1)
+
+    resource_requirements = {1: {"req_cpus": 4, "req_memory": 100, "req_walltime": 50}}
+
+    with mock.patch.object(planner, "_calculate_plan", return_value=(mock_plan, mock_graph)):
+        result = planner._plan_batch_mode(
+            campaign=MagicMock(),
+            resource_requirements=resource_requirements,
+            requested_resources=4,
+        )
+
+    assert isinstance(result, PlanResult)
+    assert result.qos is None
+    assert result.ncores == 4
+    assert len(result.batches) == 1
+    assert result.batches[0].plan == mock_plan
+    assert result.batches[0].graph is mock_graph

--- a/tests/test_planner_base.py
+++ b/tests/test_planner_base.py
@@ -83,7 +83,7 @@ def test_planner_plan_not_implemented(mock_os, mock_ru):
 @patch("socm.planner.base.ru")
 @patch("socm.planner.base.os")
 def test_planner_replan_not_implemented(mock_os, mock_ru):
-    """Test that plan method raises NotImplementedError."""
+    """Test that replan method raises NotImplementedError."""
     mock_ru.generate_id.return_value = "planner.0003"
     mock_ru.Logger.return_value = Mock()
     mock_ru.ID_CUSTOM = "custom"

--- a/tests/test_planner_base.py
+++ b/tests/test_planner_base.py
@@ -7,8 +7,8 @@ import pytest
 
 @patch("socm.planner.base.ru")
 @patch("socm.planner.base.os")
-@patch("socm.planner.base.nx")
-def test_planner_initialization(mock_nx, mock_os, mock_ru):
+def test_planner_initialization(
+    mock_os, mock_ru):
     """Test Planner class initialization."""
     # Mock the dependencies
     mock_ru.generate_id.return_value = "planner.0001"
@@ -46,8 +46,7 @@ def test_planner_initialization(mock_nx, mock_os, mock_ru):
 
 @patch("socm.planner.base.ru")
 @patch("socm.planner.base.os")
-@patch("socm.planner.base.nx")
-def test_planner_initialization_with_none_values(mock_nx, mock_os, mock_ru):
+def test_planner_initialization_with_none_values(mock_os, mock_ru):
     """Test Planner initialization with None values."""
     mock_ru.generate_id.return_value = "planner.0002"
     mock_ru.Logger.return_value = Mock()
@@ -67,8 +66,7 @@ def test_planner_initialization_with_none_values(mock_nx, mock_os, mock_ru):
 
 @patch("socm.planner.base.ru")
 @patch("socm.planner.base.os")
-@patch("socm.planner.base.nx")
-def test_planner_plan_not_implemented(mock_nx, mock_os, mock_ru):
+def test_planner_plan_not_implemented(mock_os, mock_ru):
     """Test that plan method raises NotImplementedError."""
     mock_ru.generate_id.return_value = "planner.0003"
     mock_ru.Logger.return_value = Mock()
@@ -82,15 +80,12 @@ def test_planner_plan_not_implemented(mock_nx, mock_os, mock_ru):
     with pytest.raises(NotImplementedError, match="Plan method is not implemented"):
         planner.plan()
 
-
 @patch("socm.planner.base.ru")
 @patch("socm.planner.base.os")
-@patch("socm.planner.base.nx")
-def test_planner_replan_with_parameters(mock_nx, mock_os, mock_ru):
-    """Test replan method with all parameters provided."""
-    mock_logger = Mock()
-    mock_ru.generate_id.return_value = "planner.0004"
-    mock_ru.Logger.return_value = mock_logger
+def test_planner_replan_not_implemented(mock_os, mock_ru):
+    """Test that plan method raises NotImplementedError."""
+    mock_ru.generate_id.return_value = "planner.0003"
+    mock_ru.Logger.return_value = Mock()
     mock_ru.ID_CUSTOM = "custom"
     mock_os.getcwd.return_value = "/test/path"
 
@@ -98,109 +93,5 @@ def test_planner_replan_with_parameters(mock_nx, mock_os, mock_ru):
 
     planner = Planner()
 
-    # Mock the plan method to return a value
-    expected_plan = [("workflow1", range(0, 10), 100.0, 0.0)]
-    planner.plan = Mock(return_value=expected_plan)
-
-    # Test replan with parameters
-    mock_campaign = ["workflow1"]
-    mock_resources = range(0, 10)
-    mock_resource_requirements = {"1": {"memory": 1000}}
-
-    result = planner.replan(
-        campaign=mock_campaign,
-        resources=mock_resources,
-        resource_requirements=mock_resource_requirements,
-        start_time=50,
-    )
-
-    # Verify that plan was called with correct parameters
-    planner.plan.assert_called_once_with(
-        campaign=mock_campaign,
-        resources=mock_resources,
-        resource_requirements=mock_resource_requirements,
-        start_time=50,
-    )
-
-    # Verify result
-    assert result == expected_plan
-    assert planner._plan == expected_plan
-
-    # Verify logger was called for replanning
-    mock_logger.debug.assert_called_with("Replanning")
-
-
-@patch("socm.planner.base.ru")
-@patch("socm.planner.base.os")
-@patch("socm.planner.base.nx")
-def test_planner_replan_without_parameters(mock_nx, mock_os, mock_ru):
-    """Test replan method with missing parameters."""
-    mock_logger = Mock()
-    mock_ru.generate_id.return_value = "planner.0005"
-    mock_ru.Logger.return_value = mock_logger
-    mock_ru.ID_CUSTOM = "custom"
-    mock_os.getcwd.return_value = "/test/path"
-
-    from socm.planner.base import Planner
-
-    planner = Planner()
-    planner.plan = Mock()
-
-    # Test replan without campaign parameter
-    result = planner.replan(resources=range(0, 10), resource_requirements={"1": {"memory": 1000}})
-
-    # Plan should not be called
-    planner.plan.assert_not_called()
-
-    # Should log "Nothing to plan for"
-    mock_logger.debug.assert_called_with("Nothing to plan for")
-
-    # Should return the current plan (which is empty list by default)
-    assert result == []
-
-
-@patch("socm.planner.base.ru")
-@patch("socm.planner.base.os")
-@patch("socm.planner.base.nx")
-def test_planner_replan_partial_parameters(mock_nx, mock_os, mock_ru):
-    """Test replan method with only some parameters provided."""
-    mock_logger = Mock()
-    mock_ru.generate_id.return_value = "planner.0006"
-    mock_ru.Logger.return_value = mock_logger
-    mock_ru.ID_CUSTOM = "custom"
-    mock_os.getcwd.return_value = "/test/path"
-
-    from socm.planner.base import Planner
-
-    planner = Planner()
-    planner.plan = Mock()
-
-    # Test replan with only campaign and resources (missing resource_requirements)
-    _ = planner.replan(campaign=["workflow1"], resources=range(0, 10))
-
-    # Plan should not be called because resource_requirements is missing
-    planner.plan.assert_not_called()
-
-    # Should log "Nothing to plan for"
-    mock_logger.debug.assert_called_with("Nothing to plan for")
-
-
-@patch("socm.planner.base.ru")
-@patch("socm.planner.base.os")
-@patch("socm.planner.base.nx")
-def test_planner_logger_configuration(mock_nx, mock_os, mock_ru):
-    """Test that logger is configured correctly."""
-    mock_ru.generate_id.return_value = "planner.0007"
-    mock_logger = Mock()
-    mock_ru.Logger.return_value = mock_logger
-    mock_ru.ID_CUSTOM = "custom"
-    mock_os.getcwd.return_value = "/test/cwd"
-
-    from socm.planner.base import Planner
-
-    planner = Planner(sid="test_session_id")
-
-    # Verify logger was configured with correct parameters
-    mock_ru.Logger.assert_called_once_with(name="planner.0007", level="DEBUG", path="/test/cwd/test_session_id")
-
-    assert planner._logger == mock_logger
+    with pytest.raises(NotImplementedError, match="Replan method is not implemented"):
+        planner.replan()


### PR DESCRIPTION
  Campaigns that exceed the walltime of any single SLURM QoS policy used to fail at
  planning time. This PR splits them into sequential pilot submissions that each fit
  within the best available QoS, without replanning between batches.

  **What changed**

  Planner — plan() now returns a PlanResult(qos, ncores, batches) instead of a raw
  tuple. When no single QoS covers both the required cores and the campaign deadline,
  the HEFT schedule is split into time-bounded Batch objects. Each batch gets its own
  dependency subgraph; cross-batch edges are dropped since sequential execution
  guarantees ordering.

  Enactor — Added teardown() to cancel the current pilot without closing the session, so
   setup() can be called again for the next batch.

  Bookkeeper — work() loops over batches: submits a pilot, runs workflows, tears down
  the pilot, then repeats. Two new threading events coordinate the loop: _batch_finished
   (set by state_update_cb when all batch workflows complete) and _planning_done
  (replaces a busy-wait spinloop in run()). The campaign objective is checked once
  before execution starts; _objective is no longer overwritten with per-batch walltime.

  **Limitations**

  - Remote execution schema only; batch mode still produces a single submission.
  - Single QoS across all batches; no replanning between batches.


Closes #80 